### PR TITLE
Secure MCP server endpoints

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,6 +10,8 @@ DATABASE_URL=sqlite:///data/league_stats.db
 # python -c 'import secrets; print(f"JWT_SECRET_KEY={secrets.token_urlsafe(64)}")'
 SECRET_KEY=your-very-random-secret-key-here
 JWT_SECRET_KEY=your-very-random-jwt-secret-key-here-minimum-32-chars
+# API key for the MCP server (set to a strong random value)
+MCP_API_KEY=change-me
 
 # Environment Configuration
 ENVIRONMENT=development  # Set to 'production' for production deployments


### PR DESCRIPTION
## Summary
- restrict the MCP server
  - add API key requirement
  - allow only read-only `SELECT` queries
- document new `MCP_API_KEY` in `.env.sample`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840cc43bea08323a78f1933ccfde478