### PR TITLE
Fix jersey number parsing

### DIFF
--- a/app/services/import_services/csv_parser.py
+++ b/app/services/import_services/csv_parser.py
@@ -55,13 +55,13 @@ class CSVParser:
                 team_name = row["team_name"].strip()
                 player_name = row["player_name"].strip()
 
-                try:
-                    jersey_number = str(int(row["jersey_number"]))  # Validate as int, store as string
-                except (ValueError, TypeError):
+                jersey_number_raw = row["jersey_number"].strip()
+                if not jersey_number_raw.isdigit():
                     typer.echo(
                         f"Warning: Invalid jersey number '{row['jersey_number']}' for player '{player_name}'. Skipping."
                     )
                     continue
+                jersey_number = jersey_number_raw
 
                 if team_name not in team_data:
                     team_data[team_name] = {"player_count": 0}


### PR DESCRIPTION
## Summary
- keep jersey numbers as strings when reading roster CSVs
- validate jersey number strings with `.isdigit()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840d16d98148323895cc74674992843