### PR TITLE
Fix missing quarter data bug

### DIFF
--- a/app/reports/report_generator.py
+++ b/app/reports/report_generator.py
@@ -317,16 +317,15 @@ class ReportGenerator:
             Dictionary mapping quarter numbers to either the actual stat object
             or a dummy object with zeroed stats
         """
-        # Create a dictionary to map quarter numbers to stats
+
+        # Normalize input into a dictionary keyed by quarter number
         quarter_map = {}
-
-        # If quarter_stats is already a dictionary with int keys (from tests)
-        if isinstance(quarter_stats, dict) and all(isinstance(k, int) for k in quarter_stats):
-            return quarter_stats
-
-        # Fill in with actual data
-        for qs in quarter_stats:
-            quarter_map[qs.quarter_number] = qs
+        if isinstance(quarter_stats, dict):
+            # Copy to avoid mutating caller's dictionary and ensure int keys
+            quarter_map = {int(k): v for k, v in quarter_stats.items() if isinstance(k, int | str)}
+        else:
+            for qs in quarter_stats:
+                quarter_map[qs.quarter_number] = qs
 
         # Create dummy stats for missing quarters
         for q in range(1, quarters + 1):


### PR DESCRIPTION
## Summary
- ensure `_handle_missing_quarter_data` fills gaps even when a dictionary is passed
- address ruff lint warning by using union syntax in `isinstance`

## Testing
- `ruff check . --quiet`
- `pytest tests/unit/utils/test_stats_calculator.py::TestCalculatePercentage::test_positive_percentage -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840cc1b232883239c8ebf7c0b815e57