### PR TITLE
Remove deprecated banner css references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ v0.4.10
 - Unit tests for team logo template helpers
 
 ### Refactoring / Optimization
-- Eliminated inline CSS styles across 18+ templates by consolidating into dedicated component files (banners.css, team-logos.css)
+- Eliminated inline CSS styles across 18+ templates by consolidating into dedicated component files (team-logos.css)
 - Removed 328 lines of inline CSS from games/detail.html and organized into component files (game-detail.css, box-score.css)
 
 ### Bug Fixes

--- a/app/web_ui/static/css/main.css
+++ b/app/web_ui/static/css/main.css
@@ -2,7 +2,6 @@
 /* Mobile-first responsive design with consolidated styles */
 
 /* Component imports - must come first */
-@import url('components/banners.css');
 @import url('components/team-logos.css');
 @import url('components/game-detail.css');
 @import url('components/box-score.css');

--- a/app/web_ui/templates/base.html
+++ b/app/web_ui/templates/base.html
@@ -9,7 +9,6 @@
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/main.css">
-    <link rel="stylesheet" href="/static/css/components/banner.css">
     {% block extra_head %}{% endblock %}
 </head>
 <body>


### PR DESCRIPTION
## Summary
- strip banner.css link from templates
- remove banners.css import from main stylesheet
- update changelog wording

## Testing
- `ruff check`
- `pytest -q` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_68420c59d25c8323897b95ac0b675efa