### PR TITLE
Enable player name links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v0.4.23
+-------
+
+### Changes
+* Added links to player detail pages from players list and statistics tables
+
 v0.1.22
 -------
 

--- a/app/web_ui/templates/players/index.html
+++ b/app/web_ui/templates/players/index.html
@@ -599,7 +599,7 @@ async function loadPlayers() {
                     <td data-label="Name">
                         <div style="display: flex; align-items: center; gap: 0.5rem;">
                             ${getPlayerPortraitSmall(player)}
-                            <strong>${player.name}</strong>
+                            <a href="/players/${player.id}" class="player-link"><strong>${player.name}</strong></a>
                         </div>
                     </td>
                     <td data-label="Team">${player.team_name}</td>
@@ -848,7 +848,7 @@ async function loadPlayerStatistics() {
                 row.setAttribute('data-total-points', player.total_points);
                 row.innerHTML = `
                     <td data-label="#"><strong>#${player.jersey_number}</strong></td>
-                    <td data-label="Player"><strong>${player.player_name}</strong></td>
+                    <td data-label="Player"><a href="/players/${player.player_id}" class="player-link"><strong>${player.player_name}</strong></a></td>
                     <td data-label="Team">${player.team_name}</td>
                     <td data-label="GP">${player.games_played}</td>
                     <td data-label="PPG">${player.points_per_game}</td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "basketball_stats_tracker"
-version = "0.4.22"
+version = "0.4.23"
 description = "A simple web app for tracking basketball game statistics."
 authors = [
   { name = "David 'Jedi' Lewis", email = "highwayoflife@gmail.com" }

--- a/tests/integration/test_ui_validation.py
+++ b/tests/integration/test_ui_validation.py
@@ -372,6 +372,17 @@ class TestUIValidation:
             "Player rows should have data-total-points attribute set"
         )
 
+    def test_players_page_javascript_player_links(self, docker_containers):
+        """Test that player tables link names to player detail pages."""
+        response = requests.get(f"{BASE_URL}/players")
+        assert response.status_code == 200
+
+        content = response.text
+        assert 'href="/players/${player.id}"' in content, "Player list should create links to player detail pages"
+        assert 'href="/players/${player.player_id}"' in content, (
+            "Statistics table should link player names to detail pages"
+        )
+
     def test_teams_page_loads(self, docker_containers):
         """Test that the teams page loads successfully."""
         response = requests.get(f"{BASE_URL}/teams")


### PR DESCRIPTION
## Summary
- link player names on the players list and statistics list to their detail pages
- verify links in UI validation tests
- bump version to 0.4.23

## Testing
- `make test` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68657b33689c8323bd3b18e25219ab4b