### PR TITLE
feat: enhance player awards system for game-specific tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+v0.5.4
+------
+
+### Bug Fixes
+- **Critical Dub Club Award Fix**: Fixed Dub Club award only being given to one player per week instead of all qualifying players
+  - **Root Issue**: Unique constraint prevented multiple players from receiving the same award type in the same week
+  - **Solution**: Added `game_id` field to PlayerAward model to track per-game awards
+  - **Database Changes**: Updated unique constraint to include `game_id`, allowing multiple awards per player per week for different games
+  - **Behavior Fix**: Now correctly awards EVERY player who scores 20+ points in ANY game (previously only the first player processed per week)
+  - **Impact**: Players who score 20+ in multiple games during the same week now receive multiple Dub Club awards as intended
+- **Dashboard Awards Caching Issue**: Fixed player awards on dashboard always showing old results after recalculation
+  - Added `@invalidate_cache_after` decorator to `/calculate-awards` endpoint
+  - Dashboard cache (24-hour TTL) now properly invalidates when awards are recalculated
+  - Users will see updated award results immediately instead of waiting up to 24 hours for cache expiration
+- **Code Quality Improvement**: Eliminated code duplication in player detail template
+  - Extracted percentage calculation logic into reusable `calculatePercentages(game)` helper function
+  - Removed duplicate calculation blocks between desktop and mobile views
+  - Follows DRY principle for better maintainability and consistency
+
+### Database Changes
+- **PlayerAward Schema Enhancement**: Added `game_id` field for proper per-game award tracking
+  - Migration: `302e946efab0_add_game_id_field_to_playeraward_for_.py`
+  - Updated unique constraint from `(player_id, award_type, season, week_date)` to `(player_id, award_type, season, week_date, game_id)`
+  - Enables proper tracking of multiple awards per player per week for different games
+
+
 v0.5.3
 ------
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A comprehensive basketball statistics management system designed for small leagu
 
 | Metric | Value |
 |--------|-------|
-| **Tests** | 1022 total (964 ✅ passed, 2 ❌ failed, 29 ⏭️ skipped, 27 ⚠️ errors) |
+| **Tests** | 1024 total (966 ✅ passed, 3 ❌ failed, 29 ⏭️ skipped, 26 ⚠️ errors) |
 | **Test Files** | 110 files (72 unit, 32 integration, 6 functional) |
 | **Code Coverage** | 53% (4,953 / 9,294 executable lines) |
 | **Source Code** | 100 Python files (23k total LOC) |
@@ -17,7 +17,7 @@ A comprehensive basketball statistics management system designed for small leagu
 | **Python Version** | 3.11+ |
 | **Code Quality** | Ruff linting + pytest |
 | **License** | MIT |
-| **Version** | 0.5.2 |
+| **Version** | 0.5.4 |
 
 <!-- PROJECT_STATS_END -->
 

--- a/app/services/awards_service.py
+++ b/app/services/awards_service.py
@@ -911,7 +911,7 @@ def _calculate_dub_club_winners(
         return []
 
     # Create awards for all qualifying performances
-    winners = []
+    winners = set()
     for performance in qualifying_performances:
         award = create_player_award_safe(
             session=session,
@@ -923,7 +923,7 @@ def _calculate_dub_club_winners(
             game_id=performance["game_id"],
         )
         if award:
-            winners.append(performance["player_id"])
+            winners.add(performance["player_id"])
             logger.debug(
                 f"Awarded Dub Club to player {performance['player_id']} "
                 + f"for {performance['points']} points in game {performance['game_id']} "
@@ -931,7 +931,7 @@ def _calculate_dub_club_winners(
             )
 
     session.flush()
-    return winners
+    return list(winners)
 
 
 def calculate_marksman_award(session: Session, season: str | None = None, recalculate: bool = False) -> dict[str, int]:

--- a/app/web_ui/routers/players.py
+++ b/app/web_ui/routers/players.py
@@ -947,6 +947,7 @@ async def get_calculation_status():
 
 
 @router.post("/calculate-awards")
+@invalidate_cache_after
 async def calculate_player_awards(
     request: AwardCalculationRequest,
     current_user: User = Depends(get_current_user),

--- a/migrations/versions/302e946efab0_add_game_id_field_to_playeraward_for_.py
+++ b/migrations/versions/302e946efab0_add_game_id_field_to_playeraward_for_.py
@@ -1,0 +1,45 @@
+"""Add game_id field to PlayerAward for per-game awards
+
+Revision ID: 302e946efab0
+Revises: 876bafcd6862
+Create Date: 2025-07-27 15:00:51.080350
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "302e946efab0"
+down_revision = "876bafcd6862"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Drop the existing unique constraint
+    op.drop_constraint("unique_player_award", "player_awards", type_="unique")
+
+    # Add game_id column for per-game awards (like dub_club)
+    op.add_column("player_awards", sa.Column("game_id", sa.Integer(), nullable=True))
+    op.create_foreign_key("fk_player_awards_game_id", "player_awards", "games", ["game_id"], ["id"])
+
+    # Create new unique constraint including game_id to allow multiple awards per player per week
+    # but prevent duplicates for the same game
+    op.create_unique_constraint(
+        "unique_player_award", "player_awards", ["player_id", "award_type", "season", "week_date", "game_id"]
+    )
+
+
+def downgrade():
+    # Drop the new unique constraint
+    op.drop_constraint("unique_player_award", "player_awards", type_="unique")
+
+    # Drop the foreign key and game_id column
+    op.drop_constraint("fk_player_awards_game_id", "player_awards", type_="foreignkey")
+    op.drop_column("player_awards", "game_id")
+
+    # Restore the old unique constraint
+    op.create_unique_constraint(
+        "unique_player_award", "player_awards", ["player_id", "award_type", "season", "week_date"]
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "basketball_stats_tracker"
-version = "0.5.3"
+version = "0.5.4"
 description = "A simple web app for tracking basketball game statistics."
 authors = [
   { name = "David 'Jedi' Lewis", email = "highwayoflife@gmail.com" }


### PR DESCRIPTION
- Add `game_id` field to `PlayerAward` model for per-game awards
- Update unique constraint to allow multiple awards per player per week
- Modify award calculation logic to track qualifying performances
- Fix dashboard caching issue for updated award results
- Improve code quality by eliminating duplication in award calculations